### PR TITLE
Add GitHub Documentation for Developers

### DIFF
--- a/.github/docs/setting-up-your-local-development-environment.md
+++ b/.github/docs/setting-up-your-local-development-environment.md
@@ -1,0 +1,46 @@
+# 🌀 Setting Up Your Local Development Environment
+
+This section will guide you through setting up your environment for local development.
+
+## Prerequisites
+
+Before proceeding, ensure your system meets the following requirements:
+
+- **Python**: Version 3.8.1 or higher. [Download Python](https://www.python.org/)
+- **Linux System** (Recommended): While not mandatory, using a Linux system or the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/fr-fr/windows/wsl/install) simplifies library installation.
+
+## Dependency Installation
+
+### System Libraries
+
+Install the required system libraries using the command below:
+
+```bash
+sudo apt install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev pngquant
+```
+
+### Python Libraries
+
+Install the necessary Python libraries using the `requirements.txt` file:
+
+```bash
+pip install -r requirements.txt
+```
+
+> **Note**: If you need to add a new python extension for some reason, remember to update the [`.github/workflows/deploy.yml`](../workflows/deploy.yml) file.
+
+## Useful Commands
+
+### Running the Website Locally
+
+To serve the website locally, use the following command:
+
+```bash
+mkdocs serve
+```
+
+> **Note**: If you wish to use a port other than the default `8000`, specify it using the `-a` option:
+
+```bash
+mkdocs serve -a localhost:8080
+```

--- a/.github/docs/tools-and-resources.md
+++ b/.github/docs/tools-and-resources.md
@@ -1,0 +1,35 @@
+# 🔧 Tools & Resources
+
+This document provides a list of tools and resources to assist you in making high-quality contributions.
+
+## Choose a Reliable Text Editor
+
+The tool you use to edit and create content is crucial. Choose one that suits your needs.
+
+If you're unsure, consider using [Visual Studio Code](https://code.visualstudio.com/).
+
+## Implement a Linter
+
+To minimize errors, consider using a linter specifically for `markdown` files, such as [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).
+
+> Note: The linter can utilize the `.markdownlint.json` file to observe any disabled or modified rules.
+
+## Utilize Helpful Tools & Extensions
+
+Here's a curated list of useful extensions for [Visual Studio Code](https://code.visualstudio.com/):
+
+- [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint): A linter for markdown files.
+- [Trailing Spaces](https://marketplace.visualstudio.com/items?itemName=shardulm94.trailing-spaces): Highlights unnecessary spaces.
+- [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense): Assists with navigating local files.
+- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode): A code formatter that supports markdown files.
+- [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml): Provides YAML file support.
+- [ms-vscode-remote.remote-wsl](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl): Enables usage with WSL.
+
+## Useful Resources
+
+Below are some resources that you might find beneficial:
+
+- [MkDocs](https://www.mkdocs.org/)
+- [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
+- [Markdown Guide](https://www.markdownguide.org/)
+- [Markdown Rules](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md)

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .docusaurus
 .cache-loader
 
+# Mkdocs generated files
+.cache/
+
 # Misc
 .DS_Store
 .env.local

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD033": false
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "shardulm94.trailing-spaces",
+    "christian-kohler.path-intellisense",
+    "esbenp.prettier-vscode",
+    "redhat.vscode-yaml",
+    "ms-vscode-remote.remote-wsl"
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# 📖 Contributing to Gillian's GTA IV Modding Guide
+
+First and foremost, thank you for considering a contribution to Gillian's GTA IV Modding Guide! 🎉 Your knowledge, expertise, and dedication will help us enhance this guide, benefiting the entire modding community.
+
+## 🚀 Getting Started
+
+Before diving in, here's a summary of what you should know:
+
+### Table of Contents
+
+- [🐛 Reporting Bugs and Issues](#-reporting-bugs-and-issues)
+- [✨ Suggesting Enhancements](#-suggesting-enhancements)
+- To start developing this guide, refer to:
+  - [📜 Coding Style Guide](#-coding-style-guide)
+  - [🌍 Pull Request Process](#-pull-request-process)
+  - [🌀 Setting Up Your Local Development Environment](.github/docs/setting-up-your-local-development-environment.md)
+  - [🔧 Tools & Resources](.github/docs/tools-and-resources.md)
+
+---
+
+## 🐛 Reporting Bugs and Issues
+
+If you've identified a bug or issue:
+
+1. **Check Existing Issues**: Before creating a new issue, please check [existing issues](https://github.com/gillian-guide/gillian-guide.github.io/issues) to avoid duplicates. Also, check on the [Discord server](https://discord.gg/zwmsQqExbQ), and don't forget to consult the [Troubleshooting page](https://gillian-guide.github.io/troubleshooting/) beforehand.
+2. **Create a New Issue**: If your bug hasn't been reported, open a [new issue on GitHub](https://github.com/gillian-guide/gillian-guide.github.io/issues/new) or create a ticket on the [Discord server](https://discord.gg/zwmsQqExbQ), providing as much detail as possible.
+
+## ✨ Suggesting Enhancements
+
+We are always looking for ways to improve. If you have a suggestion:
+
+1. **Open a Discussion or Issue**: Share your ideas on the [Discord server](https://discord.gg/zwmsQqExbQ).
+2. **Provide Details**: Ensure your proposal is detailed, explaining both the benefits and any potential challenges.
+
+## 📜 Coding Style Guide
+
+This project uses [MkDocs Material](https://squidfunk.github.io/mkdocs-material/), a framework that converts `markdown` files into a static documentation website. Learn more about [markdown](https://www.markdownguide.org/).
+
+For clarity, adhere to the default [markdown rules](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md). The [🔧 Tools & Resources](.github/docs/tools-and-resources.md) can assist you.
+
+- Some of these rules can be bypassed in the `.markdownlint.json` file, but only when absolutely necessary. Here is the complete list of currently disabled rules:
+  - [MD013 - Line length](https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md)
+  - [MD033 - Inline HTML](https://github.com/DavidAnson/markdownlint/blob/main/doc/md033.md#md033---inline-html)
+- When including an emoji in a title, you might encounter the [MD051 - Link fragments should be valid](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md#md051---link-fragments-should-be-valid) error. To resolve this, simply exclude the emoji from your link. For example: `#-my-car` would target `🚗 My Car`.
+
+## 🌍 Pull Request Process
+
+If you're ready to contribute:
+
+1. **Fork & Clone**: Fork the repository and clone it to your local machine.
+2. **Branch**: Always create and work in a new branch, naming it appropriately.
+3. **Commit & Push**: Commit your changes and push them to your fork.
+4. **Open a Pull Request**: Return to this repository and create a new pull request, detailing your changes and motivations.
+
+---
+
+Thank you once again for your interest in contributing! Together, we can make Gillian's GTA IV Modding Guide the premier resource for the community.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Gillian's GTA IV Modding Guide
+
   <a href="https://discord.gg/zwmsQqExbQ">
     <img src="https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat" />
   </a>
@@ -6,6 +7,8 @@
 This is the repository for my [GTA IV Modding Guide](https://gillian-guide.github.io/).
 
 If you have some issues with the guide, post them on the [Issues](https://github.com/gillian-guide/gillian-guide.github.io/issues) page or on my [Discord server](https://discord.gg/zwmsQqExbQ).
+For more details on reporting, refer to: [🐛 Reporting Bugs and Issues](CONTRIBUTING.md#-reporting-bugs-and-issues)
+
+Interested in contributing? Check out [📖 Contributing to Gillian's GTA IV Modding Guide](CONTRIBUTING.md).
 
 You can see updates to the guide in an organized way on the [Releases](https://github.com/gillian-guide/gillian-guide.github.io/releases) page.
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs-material
+mkdocs-static-i18n
+mkdocs-glightbox
+pillow
+cairosvg


### PR DESCRIPTION
I found it useful to create some documentation about the documentation 🙂. The main goal is to provide more resources on how to contribute to this great Guide! Feel free to revise any of the rules. I wrote them based on our discussion on your Discord server.

A brief summary of the additions:

- Link in the README.md to CONTRIBUTING.md
- A CONTRIBUTING.md file
- Documentation for setting up local development
- A resources & tools page with tools I personally like to use

> You can review all links and documentation on my fork at [chore/add-some-developer-documentation](https://github.com/Nougatos/gillian-guide.github.io/tree/chore/add-some-developer-documentation).

If any of these additions are inappropriate, I'm happy to adjust them to better align with your vision. 😉
